### PR TITLE
Add functionality to change start states with error checking in Build mode

### DIFF
--- a/src/SharedModel.elm
+++ b/src/SharedModel.elm
@@ -1,5 +1,7 @@
-module SharedModel exposing (MachineType(..), SharedModel, init)
+module SharedModel exposing (MachineType(..), SharedModel, init, machineModeButtons)
 
+import GraphicSVG exposing (..)
+import Helpers exposing (..)
 import Machine exposing (Machine)
 
 
@@ -19,3 +21,57 @@ init =
     { machine = Machine.test
     , machineType = DFA
     }
+
+
+machineModeButtons : MachineType -> Float -> Float -> (MachineType -> msg) -> Shape msg
+machineModeButtons mtype winX winY changeMsg =
+    group
+        [ group
+            [ roundedRect 30 15 1
+                |> filled
+                    (if mtype == DFA then
+                        finsmLightBlue
+
+                     else
+                        blank
+                    )
+                |> addOutline (solid 1) darkGray
+            , text "DFA"
+                |> centered
+                |> fixedwidth
+                |> filled
+                    (if mtype == DFA then
+                        white
+
+                     else
+                        darkGray
+                    )
+                |> move ( 0, -4 )
+            ]
+            |> move ( -winX / 2 + 20, winY / 2 - 32 )
+            |> notifyTap (changeMsg DFA)
+        , group
+            [ roundedRect 30 15 1
+                |> filled
+                    (if mtype == NFA then
+                        finsmLightBlue
+
+                     else
+                        blank
+                    )
+                |> addOutline (solid 1) darkGray
+            , text "NFA"
+                |> centered
+                |> fixedwidth
+                |> filled
+                    (if mtype == NFA then
+                        white
+
+                     else
+                        darkGray
+                    )
+                |> move ( 0, -4 )
+            ]
+            |> move ( -winX / 2 + 52, winY / 2 - 32 )
+            |> notifyTap (changeMsg NFA)
+        ]

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -1,4 +1,4 @@
-module Simulating exposing (HoverError, InputTape, Model(..), Msg(..), PersistentModel, TapeStatus(..), checkTape, checkTapes, checkTapesNoStatus, delta, deltaHat, epsTrans, initPModel, inputTapeDecoder, inputTapeDictDecoder, inputTapeEncoder, isAccept, latexKeyboard, machineDefn, machineModeButtons, onEnter, onExit, renderTape, subscriptions, update, view)
+module Simulating exposing (HoverError, InputTape, Model(..), Msg(..), PersistentModel, TapeStatus(..), checkTape, checkTapes, checkTapesNoStatus, delta, deltaHat, epsTrans, initPModel, inputTapeDecoder, inputTapeDictDecoder, inputTapeEncoder, isAccept, latexKeyboard, machineDefn, onEnter, onExit, renderTape, subscriptions, update, view)
 
 import Array exposing (Array)
 import Browser.Events
@@ -758,7 +758,7 @@ view env ( model, pModel, sModel ) =
                     ]
                     |> move ( 0, -winY / 3 )
         , (GraphicSVG.map MachineMsg <| Machine.view env Regular sModel.machine pModel.currentStates transMistakes) |> move ( 0, winY / 6 )
-        , machineModeButtons sModel.machineType winX winY
+        , machineModeButtons sModel.machineType winX winY ChangeMachine
         ]
 
 
@@ -984,58 +984,4 @@ latexKeyboard w h chars =
         [ oneRow topRow (fillOutExtras 10 9 chars) |> move ( -keyW / 3, 0 )
         , oneRow homeRow (fillOutExtras 9 0 chars) |> move ( -keyW / 3, -keyH - 2 )
         , oneRow botRow (fillOutExtras 7 19 chars) |> move ( -keyW, -(keyH + 2) * 2 )
-        ]
-
-
-machineModeButtons : MachineType -> Float -> Float -> Shape Msg
-machineModeButtons mtype winX winY =
-    group
-        [ group
-            [ roundedRect 30 15 1
-                |> filled
-                    (if mtype == DFA then
-                        finsmLightBlue
-
-                     else
-                        blank
-                    )
-                |> addOutline (solid 1) darkGray
-            , text "DFA"
-                |> centered
-                |> fixedwidth
-                |> filled
-                    (if mtype == DFA then
-                        white
-
-                     else
-                        darkGray
-                    )
-                |> move ( 0, -4 )
-            ]
-            |> move ( -winX / 2 + 20, winY / 2 - 32 )
-            |> notifyTap (ChangeMachine DFA)
-        , group
-            [ roundedRect 30 15 1
-                |> filled
-                    (if mtype == NFA then
-                        finsmLightBlue
-
-                     else
-                        blank
-                    )
-                |> addOutline (solid 1) darkGray
-            , text "NFA"
-                |> centered
-                |> fixedwidth
-                |> filled
-                    (if mtype == NFA then
-                        white
-
-                     else
-                        darkGray
-                    )
-                |> move ( 0, -4 )
-            ]
-            |> move ( -winX / 2 + 52, winY / 2 - 32 )
-            |> notifyTap (ChangeMachine NFA)
         ]


### PR DESCRIPTION
This adds the above feature and deals with the issue mentioned in #105

Though one thing that could be a minor inconvenience - users can only currently change their machine type in Simulating mode, and that ties in with the behavior of modifying start states.