### PR TITLE
Add NPDA functionality to finsm

### DIFF
--- a/src/Building.elm
+++ b/src/Building.elm
@@ -80,7 +80,7 @@ update env msg ( model, pModel, sModel ) =
     in
     case msg of
         MachineMsg mmsg ->
-            case Debug.log "Build msg" mmsg of
+            case mmsg of
                 StartDragging st ( x, y ) ->
                     let
                         ( sx, sy ) =

--- a/src/Building.elm
+++ b/src/Building.elm
@@ -733,7 +733,7 @@ update env msg ( model, pModel, sModel ) =
                             [ "\\epsilon" ]
 
                         else
-                            parseStackPush stkPush
+                            (parseStackPush stkPush)
                     }
 
                 newMachine =

--- a/src/Building.elm
+++ b/src/Building.elm
@@ -733,7 +733,7 @@ update env msg ( model, pModel, sModel ) =
                             [ "\\epsilon" ]
 
                         else
-                            (parseStackPush stkPush)
+                            parseStackPush stkPush
                     }
 
                 newMachine =

--- a/src/Building.elm
+++ b/src/Building.elm
@@ -145,8 +145,8 @@ update env msg ( model, pModel, sModel ) =
 
                                 newTrans =
                                     { inputLabel = newInputLabel
-                                    , stackTop = ""
-                                    , stackPush = ""
+                                    , stackTop = "\\epsilon"
+                                    , stackPush = [ "\\epsilon" ]
                                     }
 
                                 newTransID =
@@ -211,10 +211,10 @@ update env msg ( model, pModel, sModel ) =
                         newInpLabel =
                             case Dict.get tId sModel.machine.transitionNames of
                                 Just n ->
-                                    ( renderSet2String n.inputLabel, n.stackTop, n.stackPush )
+                                    ( renderSet2String n.inputLabel, n.stackTop, showStackPush n.stackPush )
 
                                 Nothing ->
-                                    ( "", "", "" )
+                                    ( "", "\\epsilon", "\\epsilon" )
 
                         newLab =
                             newInpLabel
@@ -514,10 +514,10 @@ update env msg ( model, pModel, sModel ) =
                             oldTransitionName =
                                 case Dict.get tId oldMachine.transitionNames of
                                     Just n ->
-                                        ( renderSet2String n.inputLabel, n.stackTop, n.stackPush )
+                                        ( renderSet2String n.inputLabel, n.stackTop, showStackPush n.stackPush )
 
                                     _ ->
-                                        ( "", "", "" )
+                                        ( "", "\\epsilon", "\\epsilon" )
                         in
                         case sModel.machineType of
                             DFA ->
@@ -537,8 +537,8 @@ update env msg ( model, pModel, sModel ) =
                             NPDA ->
                                 if
                                     (fst newLbl == fst oldTransitionName || fst newLbl == "")
-                                        && (snd newLbl == snd oldTransitionName || snd newLbl == "")
-                                        && (thd newLbl == thd oldTransitionName || thd newLbl == "")
+                                        && (snd newLbl == snd oldTransitionName || snd newLbl == "\\epsilon")
+                                        && (thd newLbl == thd oldTransitionName || thd newLbl == "\\epsilon")
                                 then
                                     ( ( { model | machineState = SelectedArrow ( s0, tId, s1 ) }, pModel, sModel ), False, Cmd.none )
 
@@ -562,10 +562,10 @@ update env msg ( model, pModel, sModel ) =
                             oldTransName =
                                 case Dict.get tId sModel.machine.transitionNames of
                                     Just label ->
-                                        ( renderSet2String label.inputLabel, label.stackTop, label.stackPush )
+                                        ( renderSet2String label.inputLabel, label.stackTop, String.concat label.stackPush )
 
                                     Nothing ->
-                                        ( "", "", "" )
+                                        ( "", "\\epsilon", "\\epsilon" )
                         in
                         ( ( { model | machineState = EditingTransitionLabel ( s0, tId, s1 ) oldTransName }, pModel, sModel ), False, focusInput NoOp )
 
@@ -722,8 +722,18 @@ update env msg ( model, pModel, sModel ) =
 
                 newLabel =
                     { inputLabel = newTransitions
-                    , stackTop = stkTop
-                    , stackPush = stkPush
+                    , stackTop =
+                        if stkTop == "" then
+                            "\\epsilon"
+
+                        else
+                            stkTop
+                    , stackPush =
+                        if stkPush == "" then
+                            [ "\\epsilon" ]
+
+                        else
+                            parseStackPush stkPush
                     }
 
                 newMachine =
@@ -913,3 +923,13 @@ snapIcon =
             ]
             |> move ( 5, -10 )
         ]
+
+
+parseStackPush : String -> List String
+parseStackPush =
+    String.split " "
+
+
+showStackPush : List String -> String
+showStackPush =
+    String.join " "

--- a/src/Error.elm
+++ b/src/Error.elm
@@ -8,7 +8,7 @@ import Dict exposing (Dict)
 import Environment exposing (Environment)
 import GraphicSVG exposing (..)
 import Helpers exposing (..)
-import Machine exposing (Machine, StateID, TransitionID)
+import Machine exposing (Machine, MachineType(..), StateID, TransitionID)
 import Mistakes exposing (..)
 import Set exposing (Set)
 import SharedModel exposing (..)
@@ -61,7 +61,7 @@ machineCheck sModel =
             getTransitionMistakes mac
 
         allTransitionLabels =
-            List.sort <| Set.toList <| Set.remove "\\epsilon" <| List.foldr Set.union Set.empty <| Dict.values mac.transitionNames
+            List.sort <| Set.toList <| Set.remove "\\epsilon" <| List.foldr Set.union Set.empty <| List.map .inputLabel <| Dict.values mac.transitionNames
 
         catch : Maybe (Set String) -> List String
         catch ms =
@@ -74,7 +74,7 @@ machineCheck sModel =
 
         getTrans : Dict TransitionID StateID -> List String
         getTrans d =
-            (List.concatMap (\e -> Dict.get e mac.transitionNames |> catch) <| Dict.keys d) |> List.sort
+            (List.concatMap (\e -> Dict.get e mac.transitionNames |> Maybe.map .inputLabel |> catch) <| Dict.keys d) |> List.sort
 
         foldingFunc : ( StateID, Dict TransitionID StateID ) -> Error -> Error
         foldingFunc sTuple err =

--- a/src/Error.elm
+++ b/src/Error.elm
@@ -51,11 +51,15 @@ contextHasError err mtype =
                     False
 
         NPDA ->
-            if err == NoError then
-                False
+            case err of
+                EpsTransError ->
+                    True
 
-            else
-                True
+                DuplicateStates _ ->
+                    True
+
+                _ ->
+                    False
 
 
 machineCheck : SharedModel -> Error

--- a/src/Error.elm
+++ b/src/Error.elm
@@ -50,6 +50,13 @@ contextHasError err mtype =
                 _ ->
                     False
 
+        NPDA ->
+            if err == NoError then
+                False
+
+            else
+                True
+
 
 machineCheck : SharedModel -> Error
 machineCheck sModel =

--- a/src/Exporting.elm
+++ b/src/Exporting.elm
@@ -164,7 +164,7 @@ view env ( model, pModel, sModel ) =
             group []
         , case ( model, pModel.outputType ) of
             ( ShowingOutput, Tikz ) ->
-                output (winX / 2) (winY / 2) (generateTikz pModel.time sModel.machine)
+                output (winX / 2) (winY / 2) (generateTikz pModel.time sModel.machine sModel.machineType)
 
             _ ->
                 group []
@@ -299,8 +299,8 @@ output w h txt =
         ]
 
 
-generateTikz : Int -> Machine -> String
-generateTikz time machine =
+generateTikz : Int -> Machine -> MachineType -> String
+generateTikz time machine macType =
     let
         scale =
             40
@@ -364,7 +364,12 @@ generateTikz time machine =
                 transitionName =
                     case Dict.get tId machine.transitionNames of
                         Just n ->
-                            renderSet2String n.inputLabel
+                            case macType of
+                                NPDA ->
+                                    renderSet2String n.inputLabel ++ ";" ++ n.stackTop ++ ";" ++ String.join " " n.stackPush
+
+                                _ ->
+                                    renderSet2String n.inputLabel
 
                         _ ->
                             ""

--- a/src/Exporting.elm
+++ b/src/Exporting.elm
@@ -181,6 +181,9 @@ machineSelected mtype winX winY =
 
                 NFA ->
                     "NFA"
+
+                NPDA ->
+                    "NPDA"
     in
     text ("Your exported machine type: " ++ mtypeStr)
         |> centered

--- a/src/Exporting.elm
+++ b/src/Exporting.elm
@@ -141,7 +141,7 @@ view env ( model, pModel, sModel ) =
                 |> move ( winX / 6 - 100, -105 )
     in
     group
-        [ (GraphicSVG.map MachineMsg <| Machine.view env Regular sModel.machine Set.empty transMistakes) |> move ( -winX / 6, 0 )
+        [ (GraphicSVG.map MachineMsg <| Machine.view env Regular sModel.machineType sModel.machine Set.empty transMistakes) |> move ( -winX / 6, 0 )
         , machineSelected sModel.machineType winX winY
         , text "Choose format:"
             |> size 20
@@ -361,7 +361,7 @@ generateTikz time machine =
                 transitionName =
                     case Dict.get tId machine.transitionNames of
                         Just n ->
-                            renderSet2String n
+                            renderSet2String n.inputLabel
 
                         _ ->
                             ""

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -334,6 +334,19 @@ labelPosition y1 theta =
         Above
 
 
+isPrefixOf : List a -> List a -> Bool
+isPrefixOf xs ys =
+    case ( xs, ys ) of
+        ( [], _ ) ->
+            True
+
+        ( _, [] ) ->
+            False
+
+        ( x :: xs1, y :: ys1 ) ->
+            x == y && isPrefixOf xs1 ys1
+
+
 roundTo : Float -> Float -> Float
 roundTo n m =
     Basics.toFloat (round (m + n / 2) // round n * round n)

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -89,6 +89,17 @@ trashIcon =
         ]
 
 
+thickRightArrowIcon =
+    group
+        [ rect 30 25
+            |> filled black
+            |> move ( -10, 0 )
+        , triangle 25
+            |> filled black
+            |> move ( 10, 0 )
+        ]
+
+
 type LatexAlign
     = AlignLeft
     | AlignRight

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (LabelPosition(..), LatexAlign(..), add, dot, editIcon, finsmBlue, finsmLightBlue, focusInput, icon, labelPosition, latex, latexurl, mult, p, parseString2Set, parseTLabel, renderSet2String, renderString, roundPrec, roundTo, sendMsg, setMax, specialSymbols, sub, trashIcon, uncurry, vertex)
+module Helpers exposing (..)
 
 import Browser.Dom as Dom
 import GraphicSVG exposing (..)
@@ -331,3 +331,33 @@ roundTo n m =
 roundPrec : Int -> Float -> Float
 roundPrec n m =
     Basics.toFloat (round (m * Basics.toFloat (10 ^ n))) / Basics.toFloat (10 ^ n)
+
+
+fst : ( a, b, c ) -> a
+fst ( a, b, c ) =
+    a
+
+
+snd : ( a, b, c ) -> b
+snd ( a, b, c ) =
+    b
+
+
+thd : ( a, b, c ) -> c
+thd ( a, b, c ) =
+    c
+
+
+mapFst : (a -> d) -> ( a, b, c ) -> ( d, b, c )
+mapFst f ( a, b, c ) =
+    ( f a, b, c )
+
+
+mapSnd : (b -> d) -> ( a, b, c ) -> ( a, d, c )
+mapSnd f ( a, b, c ) =
+    ( a, f b, c )
+
+
+mapThd : (c -> d) -> ( a, b, c ) -> ( a, b, d )
+mapThd f ( a, b, c ) =
+    ( a, b, f c )

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -294,16 +294,19 @@ test =
     in
     Machine q delta0 start final statePositions stateTransitions stateNames transitionNames
 
+
+
 {-
-machine: { delta = Dict.fromList [(1,Dict.fromList [(0,1),(1,1),(2,1),(3,1)])], 
-            final = Set.fromList [], 
-            q = Set.fromList [1], 
-            start = Set.fromList [], 
-            stateNames = Dict.fromList [(1,"q_{1}")], 
-            statePositions = Dict.fromList [(1,(18,-53))], 
-            stateTransitions = Dict.fromList [((1,0,1),(-86,0)),((1,1,1),(-2,-61)),((1,2,1),(79,4)),((1,3,1),(0,50))], 
-            transitionNames = Dict.fromList [(0,{ inputLabel = Set.fromList ["]"], stackPush = "", stackTop = "[" }),(1,{ inputLabel = Set.fromList [], stackPush = "", stackTop = "Z" }),(2,{ inputLabel = Set.fromList ["["], stackPush = "[[", stackTop = "[" }),(3,{ inputLabel = Set.fromList ["["], stackPush = "Z[", stackTop = "Z" })] }
+   machine: { delta = Dict.fromList [(1,Dict.fromList [(0,1),(1,1),(2,1),(3,1)])],
+               final = Set.fromList [],
+               q = Set.fromList [1],
+               start = Set.fromList [],
+               stateNames = Dict.fromList [(1,"q_{1}")],
+               statePositions = Dict.fromList [(1,(18,-53))],
+               stateTransitions = Dict.fromList [((1,0,1),(-86,0)),((1,1,1),(-2,-61)),((1,2,1),(79,4)),((1,3,1),(0,50))],
+               transitionNames = Dict.fromList [(0,{ inputLabel = Set.fromList ["]"], stackPush = "", stackTop = "[" }),(1,{ inputLabel = Set.fromList [], stackPush = "", stackTop = "Z" }),(2,{ inputLabel = Set.fromList ["["], stackPush = "[[", stackTop = "[" }),(3,{ inputLabel = Set.fromList ["["], stackPush = "Z[", stackTop = "Z" })] }
 -}
+
 
 testNPDA : Machine
 testNPDA =
@@ -319,10 +322,10 @@ testNPDA =
             Set.fromList [ 0 ]
 
         final =
-            Set.fromList [ ]
+            Set.fromList []
 
         statePositions =
-            Dict.fromList [ ( 0, (  0, 0 ) ) ]
+            Dict.fromList [ ( 0, ( 0, 0 ) ) ]
 
         stateNames =
             Dict.fromList [ ( 0, "q_0" ) ]
@@ -344,7 +347,6 @@ testNPDA =
                 ]
     in
     Machine q delta0 start final statePositions stateTransitions stateNames transitionNames
-
 
 
 view : Environment -> Model -> MachineType -> Machine -> Set StateID -> TransitionMistakes -> Shape Msg

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -1,6 +1,5 @@
 module Machine exposing (..)
 
-import Debug exposing (todo)
 import Dict exposing (Dict)
 import Environment exposing (Environment)
 import GraphicSVG exposing (..)
@@ -11,7 +10,7 @@ import Html.Events exposing (onInput)
 import Json.Decode as D
 import Json.Encode as E
 import Set exposing (Set)
-import Utils exposing (decodeDict, decodePair, decodeSet, decodeTriple, encodeDict, encodePair, encodeSet, encodeTriple, textBox)
+import Utils exposing (decodeDict, decodePair, decodeSet, decodeTriple, encodeDict, encodePair, encodeSet, encodeTriple, textBox, textBox3)
 
 
 type alias StateID =
@@ -39,6 +38,12 @@ type alias TransitionLabel =
     , stackTop : String
     , stackPush : String
     }
+
+
+type LabelEditType
+    = InputLabel
+    | StackTop
+    | StackPush
 
 
 type alias StateTransitions =
@@ -101,7 +106,7 @@ type Msg
     | MouseOverStateLabel StateID
     | MouseOverTransitionLabel TransitionID
     | MouseLeaveLabel
-    | EditTransitionLabel TransitionID String
+    | EditTransitionLabel TransitionID LabelEditType String
     | EditStateLabel StateID String
     | Drag ( Float, Float )
     | TapState StateID
@@ -337,7 +342,7 @@ view env model macType machine currentStates tMistakes =
                             NPDA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
+                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ tLabel.stackPush
 
                                     Nothing ->
                                         " "
@@ -391,7 +396,7 @@ view env model macType machine currentStates tMistakes =
                             NPDA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
+                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ tLabel.stackPush
 
                                     Nothing ->
                                         " "
@@ -591,7 +596,7 @@ renderArrow macType ( x0, y0 ) ( x1, y1 ) ( x2, y2 ) r0 r1 char charID sel mista
                                         )
                                         20
                                         "LaTeX"
-                                        (EditTransitionLabel tId)
+                                        (EditTransitionLabel tId InputLabel)
 
                                 NFA ->
                                     textBox lab
@@ -603,10 +608,21 @@ renderArrow macType ( x0, y0 ) ( x1, y1 ) ( x2, y2 ) r0 r1 char charID sel mista
                                         )
                                         20
                                         "LaTeX"
-                                        (EditTransitionLabel tId)
+                                        (EditTransitionLabel tId InputLabel)
 
                                 NPDA ->
-                                    Debug.todo "TODO"
+                                    textBox3 ( lab, stkTop, stkPush )
+                                        (if List.any ((==) 0) <| List.map String.length [ lab, stkTop, stkPush ] then
+                                            80
+
+                                         else
+                                            8 * toFloat (String.length lab) + 5
+                                        )
+                                        20
+                                        ( "inputLabel", "stackTop", "stackPush" )
+                                        (EditTransitionLabel tId InputLabel)
+                                        (EditTransitionLabel tId StackTop)
+                                        (EditTransitionLabel tId StackPush)
 
                         else
                             latex tLblW
@@ -748,7 +764,7 @@ renderArrows macType machine model tMistakes =
                                                                 Set.toList tLabel.inputLabel |> renderString
 
                                                             NPDA ->
-                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
+                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ tLabel.stackPush
 
                                                     Nothing ->
                                                         ""

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -334,7 +334,7 @@ testNPDA =
             Dict.fromList <|
                 [ ( 0, { inputLabel = Set.singleton "[", stackTop = "\\bot", stackPush = [ "[", "\\bot" ] } )
                 , ( 1, { inputLabel = Set.singleton "[", stackTop = "[", stackPush = [ "[", "[" ] } )
-                , ( 2, { inputLabel = Set.singleton "\\epsilon", stackTop = "\\epsilon", stackPush = [ "[" ] } ) -- { inputLabel = Set.singleton "]", stackTop = "[", stackPush = [ "\\epsilon" ] } )
+                , ( 2, { inputLabel = Set.singleton "]", stackTop = "[", stackPush = [ "\\epsilon" ] } )
                 , ( 3, { inputLabel = Set.singleton "\\epsilon", stackTop = "\\bot", stackPush = [ "\\epsilon" ] } )
                 ]
 
@@ -380,7 +380,7 @@ view env model macType machine currentStates tMistakes =
                             DFA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        Set.toList tLabel.inputLabel |> renderString
+                                        renderSet2String tLabel.inputLabel
 
                                     Nothing ->
                                         " "
@@ -388,7 +388,7 @@ view env model macType machine currentStates tMistakes =
                             NFA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        Set.toList tLabel.inputLabel |> renderString
+                                        renderSet2String tLabel.inputLabel
 
                                     Nothing ->
                                         " "
@@ -396,7 +396,7 @@ view env model macType machine currentStates tMistakes =
                             NPDA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ String.concat tLabel.stackPush
+                                        renderSet2String tLabel.inputLabel ++ ";" ++ tLabel.stackTop ++ ";" ++ String.concat tLabel.stackPush
 
                                     Nothing ->
                                         " "
@@ -434,7 +434,7 @@ view env model macType machine currentStates tMistakes =
                             DFA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        Set.toList tLabel.inputLabel |> renderString
+                                        renderSet2String tLabel.inputLabel
 
                                     Nothing ->
                                         " "
@@ -442,7 +442,7 @@ view env model macType machine currentStates tMistakes =
                             NFA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        Set.toList tLabel.inputLabel |> renderString
+                                        renderSet2String tLabel.inputLabel
 
                                     Nothing ->
                                         " "
@@ -450,7 +450,7 @@ view env model macType machine currentStates tMistakes =
                             NPDA ->
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
-                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ String.concat tLabel.stackPush
+                                        renderSet2String tLabel.inputLabel ++ ";" ++ tLabel.stackTop ++ ";" ++ String.concat tLabel.stackPush
 
                                     Nothing ->
                                         " "
@@ -812,13 +812,13 @@ renderArrows macType machine model tMistakes =
                                                     Just tLabel ->
                                                         case macType of
                                                             DFA ->
-                                                                Set.toList tLabel.inputLabel |> renderString
+                                                                renderSet2String tLabel.inputLabel
 
                                                             NFA ->
-                                                                Set.toList tLabel.inputLabel |> renderString
+                                                                renderSet2String tLabel.inputLabel
 
                                                             NPDA ->
-                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ String.join " " tLabel.stackPush
+                                                                renderSet2String tLabel.inputLabel ++ ";" ++ tLabel.stackTop ++ ";" ++ String.join " " tLabel.stackPush
 
                                                     Nothing ->
                                                         ""

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -72,6 +72,7 @@ type alias Machine =
 type MachineType
     = DFA
     | NFA
+    | NPDA
 
 
 type Model
@@ -100,7 +101,8 @@ type Msg
     | MouseOverStateLabel StateID
     | MouseOverTransitionLabel TransitionID
     | MouseLeaveLabel
-    | EditLabel StateID String
+    | EditTransitionLabel TransitionID String
+    | EditStateLabel StateID String
     | Drag ( Float, Float )
     | TapState StateID
     | StopDragging
@@ -332,6 +334,14 @@ view env model macType machine currentStates tMistakes =
                                     Nothing ->
                                         " "
 
+                            NPDA ->
+                                case List.head <| Dict.values machine.transitionNames of
+                                    Just tLabel ->
+                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
+
+                                    Nothing ->
+                                        " "
+
                     newTransID =
                         case List.head <| Dict.keys machine.transitionNames of
                             Just char ->
@@ -374,6 +384,14 @@ view env model macType machine currentStates tMistakes =
                                 case List.head <| Dict.values machine.transitionNames of
                                     Just tLabel ->
                                         Set.toList tLabel.inputLabel |> renderString
+
+                                    Nothing ->
+                                        " "
+
+                            NPDA ->
+                                case List.head <| Dict.values machine.transitionNames of
+                                    Just tLabel ->
+                                        (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
 
                                     Nothing ->
                                         " "
@@ -573,7 +591,7 @@ renderArrow macType ( x0, y0 ) ( x1, y1 ) ( x2, y2 ) r0 r1 char charID sel mista
                                         )
                                         20
                                         "LaTeX"
-                                        (EditLabel tId)
+                                        (EditTransitionLabel tId)
 
                                 NFA ->
                                     textBox lab
@@ -585,7 +603,10 @@ renderArrow macType ( x0, y0 ) ( x1, y1 ) ( x2, y2 ) r0 r1 char charID sel mista
                                         )
                                         20
                                         "LaTeX"
-                                        (EditLabel tId)
+                                        (EditTransitionLabel tId)
+
+                                NPDA ->
+                                    Debug.todo "TODO"
 
                         else
                             latex tLblW
@@ -726,6 +747,9 @@ renderArrows macType machine model tMistakes =
                                                             NFA ->
                                                                 Set.toList tLabel.inputLabel |> renderString
 
+                                                            NPDA ->
+                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackPush ++ ";" ++ tLabel.stackTop
+
                                                     Nothing ->
                                                         ""
 
@@ -841,7 +865,7 @@ renderStates currentStates machine model env =
                                     )
                                     20
                                     "LaTeX"
-                                    (EditLabel sId)
+                                    (EditStateLabel sId)
 
                             else
                                 group

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -334,7 +334,7 @@ testNPDA =
             Dict.fromList <|
                 [ ( 0, { inputLabel = Set.singleton "[", stackTop = "\\bot", stackPush = [ "[", "\\bot" ] } )
                 , ( 1, { inputLabel = Set.singleton "[", stackTop = "[", stackPush = [ "[", "[" ] } )
-                , ( 2, { inputLabel = Set.singleton "]", stackTop = "[", stackPush = [ "\\epsilon" ] } )
+                , ( 2, { inputLabel = Set.singleton "\\epsilon", stackTop = "\\epsilon", stackPush = [ "[" ] } ) -- { inputLabel = Set.singleton "]", stackTop = "[", stackPush = [ "\\epsilon" ] } )
                 , ( 3, { inputLabel = Set.singleton "\\epsilon", stackTop = "\\bot", stackPush = [ "\\epsilon" ] } )
                 ]
 

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -670,7 +670,7 @@ renderArrow macType ( x0, y0 ) ( x1, y1 ) ( x2, y2 ) r0 r1 char charID sel mista
                                             80
 
                                          else
-                                            8 * toFloat (String.length lab) + 5
+                                            8 * toFloat (List.foldl max 0 <| List.map String.length [ lab, stkTop, stkPush ]) + 5
                                         )
                                         20
                                         ( "inputLabel", "stackTop", "stackPush" )

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -818,7 +818,7 @@ renderArrows macType machine model tMistakes =
                                                                 Set.toList tLabel.inputLabel |> renderString
 
                                                             NPDA ->
-                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ String.concat tLabel.stackPush
+                                                                (Set.toList tLabel.inputLabel |> renderString) ++ ";" ++ tLabel.stackTop ++ ";" ++ String.join " " tLabel.stackPush
 
                                                     Nothing ->
                                                         ""

--- a/src/Machine.elm
+++ b/src/Machine.elm
@@ -294,6 +294,58 @@ test =
     in
     Machine q delta0 start final statePositions stateTransitions stateNames transitionNames
 
+{-
+machine: { delta = Dict.fromList [(1,Dict.fromList [(0,1),(1,1),(2,1),(3,1)])], 
+            final = Set.fromList [], 
+            q = Set.fromList [1], 
+            start = Set.fromList [], 
+            stateNames = Dict.fromList [(1,"q_{1}")], 
+            statePositions = Dict.fromList [(1,(18,-53))], 
+            stateTransitions = Dict.fromList [((1,0,1),(-86,0)),((1,1,1),(-2,-61)),((1,2,1),(79,4)),((1,3,1),(0,50))], 
+            transitionNames = Dict.fromList [(0,{ inputLabel = Set.fromList ["]"], stackPush = "", stackTop = "[" }),(1,{ inputLabel = Set.fromList [], stackPush = "", stackTop = "Z" }),(2,{ inputLabel = Set.fromList ["["], stackPush = "[[", stackTop = "[" }),(3,{ inputLabel = Set.fromList ["["], stackPush = "Z[", stackTop = "Z" })] }
+-}
+
+testNPDA : Machine
+testNPDA =
+    let
+        q =
+            Set.fromList [ 0 ]
+
+        delta0 =
+            Dict.fromList
+                [ ( 0, Dict.fromList [ ( 0, 0 ), ( 1, 0 ), ( 2, 0 ), ( 3, 0 ) ] ) ]
+
+        start =
+            Set.fromList [ 0 ]
+
+        final =
+            Set.fromList [ ]
+
+        statePositions =
+            Dict.fromList [ ( 0, (  0, 0 ) ) ]
+
+        stateNames =
+            Dict.fromList [ ( 0, "q_0" ) ]
+
+        transitionNames =
+            Dict.fromList <|
+                [ ( 0, { inputLabel = Set.singleton "[", stackTop = "Z", stackPush = "[Z" } )
+                , ( 1, { inputLabel = Set.singleton "[", stackTop = "[", stackPush = "[[" } )
+                , ( 2, { inputLabel = Set.singleton "]", stackTop = "[", stackPush = "" } )
+                , ( 3, { inputLabel = Set.singleton "\\epsilon", stackTop = "Z", stackPush = "" } )
+                ]
+
+        stateTransitions =
+            Dict.fromList
+                [ ( ( 0, 0, 0 ), ( 0, 70 ) )
+                , ( ( 0, 1, 0 ), ( 0, -70 ) )
+                , ( ( 0, 2, 0 ), ( 70, 0 ) )
+                , ( ( 0, 3, 0 ), ( -70, 0 ) )
+                ]
+    in
+    Machine q delta0 start final statePositions stateTransitions stateNames transitionNames
+
+
 
 view : Environment -> Model -> MachineType -> Machine -> Set StateID -> TransitionMistakes -> Shape Msg
 view env model macType machine currentStates tMistakes =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -70,7 +70,7 @@ initAppModel =
 initAppRecord =
     { appState = Building Building.init
     , sharedModel = SharedModel.init
-    , simulatingData = Simulating.initPModel
+    , simulatingData = Simulating.initPModel SharedModel.init.machineType
     , buildingData = Building.initPModel
     , exportingData = Exporting.initPModel
     }
@@ -416,7 +416,7 @@ update msg model =
                                     { initSharedModel | machine = loadPayload.machine }
 
                                 initSimModel =
-                                    Simulating.initPModel
+                                    Simulating.initPModel initSharedModel.machineType
 
                                 --{ appState = Building Building.init
                                 --, sharedModel = SharedModel.init
@@ -467,7 +467,7 @@ update msg model =
                             fresh
                                 { initAppRecord
                                     | sharedModel = newSharedModel
-                                    , simulatingData = initSimModel
+                                    , simulatingData = initSimModel newSharedModel.machineType
                                 }
                     in
                     ( { model

--- a/src/Mistakes.elm
+++ b/src/Mistakes.elm
@@ -16,6 +16,7 @@ getTransitionMistakes mac =
 
 
 -- Check if an epsilon label is well-typed
+-- TODO: Check if this should be generalized to NPDAs
 
 
 checkEpsilonTransLabel : TransitionNames -> TransitionMistakes
@@ -23,8 +24,8 @@ checkEpsilonTransLabel tNames =
     let
         tMistakes =
             Dict.foldl
-                (\tid tnames tmistakes ->
-                    if not (checkTransitionValid tnames) then
+                (\tid tLabel tmistakes ->
+                    if not (checkTransitionValid tLabel.inputLabel) then
                         Set.insert tid tmistakes
 
                     else

--- a/src/SaveLoad.elm
+++ b/src/SaveLoad.elm
@@ -1045,7 +1045,7 @@ renderNew loginStatus =
             [ Grid.col []
                 [ Card.deck
                     [ Card.config []
-                        |> Card.headerH3 [] [ Html.text "DFA / NFA" ]
+                        |> Card.headerH3 [] [ Html.text "DFA / NFA / NPDA" ]
                         |> Card.block []
                             [ Block.text [] [ Html.text "Create a new Finite State Machine." ] ]
                         |> Card.footer []

--- a/src/SharedModel.elm
+++ b/src/SharedModel.elm
@@ -1,13 +1,8 @@
-module SharedModel exposing (MachineType(..), SharedModel, init, machineModeButtons)
+module SharedModel exposing (SharedModel, init, machineModeButtons)
 
 import GraphicSVG exposing (..)
 import Helpers exposing (..)
-import Machine exposing (Machine)
-
-
-type MachineType
-    = DFA
-    | NFA
+import Machine exposing (Machine, MachineType(..))
 
 
 type alias SharedModel =

--- a/src/SharedModel.elm
+++ b/src/SharedModel.elm
@@ -13,7 +13,7 @@ type alias SharedModel =
 
 init : SharedModel
 init =
-    { machine = Machine.testNPDA
+    { machine = Machine.test
     , machineType = DFA
     }
 

--- a/src/SharedModel.elm
+++ b/src/SharedModel.elm
@@ -13,7 +13,7 @@ type alias SharedModel =
 
 init : SharedModel
 init =
-    { machine = Machine.test
+    { machine = Machine.testNPDA
     , machineType = DFA
     }
 

--- a/src/SharedModel.elm
+++ b/src/SharedModel.elm
@@ -69,4 +69,28 @@ machineModeButtons mtype winX winY changeMsg =
             ]
             |> move ( -winX / 2 + 52, winY / 2 - 32 )
             |> notifyTap (changeMsg NFA)
+        , group
+            [ roundedRect 40 15 1
+                |> filled
+                    (if mtype == NPDA then
+                        finsmLightBlue
+
+                     else
+                        blank
+                    )
+                |> addOutline (solid 1) darkGray
+            , text "NPDA"
+                |> centered
+                |> fixedwidth
+                |> filled
+                    (if mtype == NPDA then
+                        white
+
+                     else
+                        darkGray
+                    )
+                |> move ( 0, -4 )
+            ]
+            |> move ( -winX / 2 + 89, winY / 2 - 32 )
+            |> notifyTap (changeMsg NPDA)
         ]

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -52,9 +52,11 @@ inputTapeDictDecoder =
 type alias InputTape =
     Array Character
 
+
 type TapeStatus
     = Fresh
     | Stale (Set String)
+
 
 type alias Configuration =
     { stack : Stack
@@ -63,14 +65,17 @@ type alias Configuration =
     , tapePos : Int
     }
 
+
 type ConfigStatus
     = Alive
     | Success
     | Deadend
 
+
 type AcceptCond
     = EmptyStack
     | FinalState
+
 
 type alias HoverError =
     Maybe Int
@@ -124,6 +129,7 @@ onExit : Environment -> ( Model, PersistentModel, SharedModel ) -> ( ( Persisten
 onExit env ( model, pModel, sModel ) =
     ( ( pModel, sModel ), False )
 
+
 designatedStart : Set StateID -> StateID
 designatedStart setStart =
     case Set.toList setStart of
@@ -132,6 +138,7 @@ designatedStart setStart =
 
         startState :: _ ->
             startState
+
 
 initPModel : MachineType -> PersistentModel
 initPModel macType =
@@ -174,19 +181,25 @@ checkTape sModel inp =
         False ->
             Stale <| Set.fromList <| Array.toList arrFilter
 
--- TODO: Add size-aware resizing and horizontal scroll
-renderConfigs : Machine -> Model -> Array String -> Int -> Float -> List Configuration -> Shape Msg
-renderConfigs machine model input tapeId winX cfgs = 
-    let
-        xPos idx = (winX / 6) * (idx - 3) + (winX / 3)
 
+
+-- TODO: Add size-aware resizing and horizontal scroll
+
+
+renderConfigs : Machine -> Model -> Array String -> Int -> Float -> List Configuration -> Shape Msg
+renderConfigs machine model input tapeId winX cfgs =
+    let
+        xPos idx =
+            (winX / 6) * (idx - 3) + (winX / 3)
     in
-    group <| List.indexedMap (\idx cfg -> renderConfig machine model input tapeId cfg |> move (xPos (toFloat idx), 0) ) cfgs
-        
+    group <| List.indexedMap (\idx cfg -> renderConfig machine model input tapeId cfg |> move ( xPos (toFloat idx), 0 )) cfgs
+
+
 renderConfig : Machine -> Model -> Array String -> Int -> Configuration -> Shape Msg
 renderConfig machine model input tapeId cfg =
     let
-        xpad = 200
+        xpad =
+            200
 
         stateName =
             case Dict.get cfg.state machine.stateNames of
@@ -198,40 +211,53 @@ renderConfig machine model input tapeId cfg =
 
         statusColour =
             case cfg.status of
-                Success -> green
-                Deadend -> red
-                _ -> blank
+                Success ->
+                    green
 
-        renderedState = group
-            [ circle 20
-                |> filled statusColour
-                |> addOutline (solid 1) black
-            , latex 25 18 "none" stateName AlignCentre
-                |> move ( 0, 9 )
-            ]
+                Deadend ->
+                    red
 
-        stackLength = toFloat (xpad*(List.length cfg.stack))
-        renderedStack = renderStack cfg.stack
-        renderedTape  = renderTape model input Fresh tapeId tapeId cfg.tapePos False
-        
+                _ ->
+                    blank
+
+        renderedState =
+            group
+                [ circle 20
+                    |> filled statusColour
+                    |> addOutline (solid 1) black
+                , latex 25 18 "none" stateName AlignCentre
+                    |> move ( 0, 9 )
+                ]
+
+        stackLength =
+            toFloat (xpad * List.length cfg.stack)
+
+        renderedStack =
+            renderStack cfg.stack
+
+        renderedTape =
+            renderTape model input Fresh tapeId tapeId cfg.tapePos False
+
         outerBox =
             rectangle (100 + stackLength) 150
                 |> outlined (solid 5) black
-                |> move (stackLength / 2, -10)
+                |> move ( stackLength / 2, -10 )
     in
     group
         [ outerBox
         , renderedState
-        , renderedStack |> move (0, -50)
-        , renderedTape |> move (25, 0)
-        ]    
+        , renderedStack |> move ( 0, -50 )
+        , renderedTape |> move ( 25, 0 )
+        ]
+
 
 renderStack : Stack -> Shape Msg
 renderStack stk =
     let
-        xpad = 20
+        xpad =
+            20
     in
-    group 
+    group
         (List.indexedMap
             (\n st ->
                 group
@@ -252,7 +278,7 @@ renderStack stk =
             )
             stk
         )
-            
+
 
 renderTape : Model -> Array String -> TapeStatus -> Int -> Int -> Int -> Bool -> Shape Msg
 renderTape model input tapeSt tapeId selectedId inputAt showButtons =
@@ -410,7 +436,6 @@ update env msg ( model, pModel, sModel ) =
 
         machineType =
             sModel.machineType
-
     in
     case msg of
         Step ->
@@ -456,24 +481,27 @@ update env msg ( model, pModel, sModel ) =
                                 |> Maybe.map first
                                 |> Maybe.withDefault Array.empty
 
-                        newCfgs = nextConfigRel oldMachine.transitionNames oldMachine.delta tape pModel.npdaAcceptCond sModel.machine.final cfgs
+                        newCfgs =
+                            nextConfigRel oldMachine.transitionNames oldMachine.delta tape pModel.npdaAcceptCond sModel.machine.final cfgs
 
-                        newStates = configToStates newCfgs
+                        newStates =
+                            configToStates newCfgs
                     in
-                        ( ( RunningNPDA newCfgs tId, { pModel | currentStates = newStates }, sModel), False, Cmd.none )
+                    ( ( RunningNPDA newCfgs tId, { pModel | currentStates = newStates }, sModel ), False, Cmd.none )
+
                 _ ->
-                    ( ( model, pModel , sModel ), False, Cmd.none )
+                    ( ( model, pModel, sModel ), False, Cmd.none )
 
         RunTape tId ->
             case machineType of
                 DFA ->
-                    ( ( Running tId (-1), pModel, sModel), False, Cmd.none )
-                
+                    ( ( Running tId -1, pModel, sModel ), False, Cmd.none )
+
                 NFA ->
-                    ( ( Running tId (-1), pModel, sModel), False, Cmd.none )
+                    ( ( Running tId -1, pModel, sModel ), False, Cmd.none )
 
                 NPDA ->
-                    ( (RunningNPDA [ { stack = [ 'Z' ], state = designatedStart test.start, status = Alive, tapePos = -1 } ] tId, pModel, sModel), False, Cmd.none) 
+                    ( ( RunningNPDA [ { stack = [ 'Z' ], state = designatedStart test.start, status = Alive, tapePos = -1 } ] tId, pModel, sModel ), False, Cmd.none )
 
         EditTape tId ->
             ( ( Editing tId, pModel, sModel ), False, Cmd.none )
@@ -993,6 +1021,7 @@ view env ( model, pModel, sModel ) =
 
             Running _ _ ->
                 Debug.todo "Running state"
+
             RunningNPDA cfgs tId ->
                 group
                     [ rect winX (winY / 3)
@@ -1224,9 +1253,12 @@ deltaHat tNames d ch states =
 
 
 -- NPDA functions
-            
+
+
 configToStates : List Configuration -> Set StateID
-configToStates = List.filter (\cfg -> cfg.status == Alive || cfg.status == Success) >> List.map .state >> Set.fromList 
+configToStates =
+    List.filter (\cfg -> cfg.status == Alive || cfg.status == Success) >> List.map .state >> Set.fromList
+
 
 nextConfigRel : TransitionNames -> Delta -> InputTape -> AcceptCond -> Set StateID -> List Configuration -> List Configuration
 nextConfigRel tNames d tape acceptCond finals cfgs =
@@ -1260,13 +1292,18 @@ nextConfig tNames d tape acceptCond finals ({ stack, state, status, tapePos } as
                 inpStk
 
         nextTape cond =
-            if cond then 0 else 1
+            if cond then
+                0
 
-        ch = Maybe.withDefault "" (Array.get (tapePos + 1) tape)
+            else
+                1
+
+        ch =
+            Maybe.withDefault "" (Array.get (tapePos + 1) tape)
     in
     case status of
         Alive ->
-            let 
+            let
                 newConfigs =
                     case Dict.get state d of
                         Just transMap ->
@@ -1274,40 +1311,61 @@ nextConfig tNames d tape acceptCond finals ({ stack, state, status, tapePos } as
                                 |> List.filterMap
                                     (\( tId, sId ) ->
                                         let
-                                            tLabel = getName tId
-                                            newStack = updateStack tLabel stack
-                                            newTapePos = tapePos + nextTape (renderSet2String tLabel.inputLabel == "\\epsilon")
-                                            newStatus = 
+                                            tLabel =
+                                                getName tId
+
+                                            newStack =
+                                                updateStack tLabel stack
+
+                                            newTapePos =
+                                                tapePos + nextTape (renderSet2String tLabel.inputLabel == "\\epsilon")
+
+                                            newStatus =
                                                 case acceptCond of
-                                                    EmptyStack -> if newStack == [] then Success else Alive
-                                                    FinalState -> if Set.member sId finals && newTapePos == Array.length tape then Success else Alive
+                                                    EmptyStack ->
+                                                        if newStack == [] then
+                                                            Success
+
+                                                        else
+                                                            Alive
+
+                                                    FinalState ->
+                                                        if Set.member sId finals && newTapePos == Array.length tape then
+                                                            Success
+
+                                                        else
+                                                            Alive
                                         in
                                         if
                                             (renderSet2String tLabel.inputLabel == ch || renderSet2String tLabel.inputLabel == "\\epsilon")
                                                 && matchStackTop tLabel.stackTop
                                         then
-                                            Just 
+                                            Just
                                                 { stack = updateStack tLabel stack
                                                 , state = sId
                                                 , status = Alive
-                                                , tapePos = tapePos + nextTape (renderSet2String tLabel.inputLabel == "\\epsilon") 
+                                                , tapePos = tapePos + nextTape (renderSet2String tLabel.inputLabel == "\\epsilon")
                                                 }
+
                                         else
-                                            Nothing                        
+                                            Nothing
                                     )
 
                         Nothing ->
                             []
             in
-            if newConfigs == []
-                then [ { config | status = Deadend } ]
-                else newConfigs
+            if newConfigs == [] then
+                [ { config | status = Deadend } ]
+
+            else
+                newConfigs
 
         Success ->
             []
 
         Deadend ->
             []
+
 
 updateStack : TransitionLabel -> Stack -> Stack
 updateStack { stackTop, stackPush } stk =

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -246,6 +246,13 @@ renderTape model input tapeSt tapeId selectedId inputAt showButtons =
                         ]
                         |> move ( toFloat <| (Array.length input + 1) * xpad, 3 )
                         |> notifyTap (DeleteTape tapeId)
+                    , group
+                        [ roundedRect 15 15 2
+                            |> filled white
+                            |> addOutline (solid 1) darkGray
+                        , thickRightArrowIcon |> scale 0.2 |> move ( 0, -1 )
+                        ]
+                        |> move ( toFloat <| (Array.length input + 2) * xpad, 2 )
                     , if not (tapeSt == Fresh) then
                         group
                             ([ triangle 20 |> filled red |> rotate 22.5
@@ -558,10 +565,10 @@ update env msg ( model, pModel, sModel ) =
                         NPDA ->
                             case model of
                                 Editing tId ->
-                                    ( ( Default tId -1 Nothing, pModel, { sModel | machineType = NPDA } ), False, Cmd.none )
+                                    ( ( Default tId -1 Nothing, pModel, { sModel | machineType = NFA } ), False, Cmd.none )
 
                                 _ ->
-                                    ( ( model, pModel, { sModel | machineType = NPDA } ), False, Cmd.none )
+                                    ( ( model, pModel, { sModel | machineType = NFA } ), False, Cmd.none )
 
                 DFA ->
                     case sModel.machineType of
@@ -604,10 +611,10 @@ update env msg ( model, pModel, sModel ) =
                         NPDA ->
                             case model of
                                 Editing tId ->
-                                    ( ( Default tId -1 Nothing, pModel, { sModel | machineType = NPDA } ), False, Cmd.none )
+                                    ( ( Default tId -1 Nothing, pModel, { sModel | machineType = DFA } ), False, Cmd.none )
 
                                 _ ->
-                                    ( ( model, pModel, { sModel | machineType = NPDA } ), False, Cmd.none )
+                                    ( ( model, pModel, { sModel | machineType = DFA } ), False, Cmd.none )
 
                 NPDA ->
                     case sModel.machineType of
@@ -861,9 +868,9 @@ machineDefn sModel mtype winX winY =
         NFA ->
             group
                 [ machineHeader
-                , latex 500 18 "blank" "let\\ N = (Q,\\Sigma,\\Delta,S,F)" AlignLeft
+                , latex 500 18 "blank" "\\textrm{let}\\ N = (Q,\\Sigma,\\Delta,S,F)" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 25 )
-                , latex 500 14 "blank" "where" AlignLeft
+                , latex 500 14 "blank" "\\textrm{where}" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 45 )
                 , latex 500 18 "blank" ("Q = \\{ " ++ String.join "," (Dict.values machine.stateNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
@@ -880,9 +887,9 @@ machineDefn sModel mtype winX winY =
         DFA ->
             group
                 [ machineHeader
-                , latex 500 18 "blank" "let\\ M = (Q,\\Sigma,\\delta,s,F)" AlignLeft
+                , latex 500 18 "blank" "\\textrm{let}\\ M = (Q,\\Sigma,\\delta,s,F)" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 25 )
-                , latex 500 14 "blank" "where" AlignLeft
+                , latex 500 14 "blank" "\\textrm{where}" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 45 )
                 , latex 500 18 "blank" ("Q = \\{ " ++ String.join "," (Dict.values machine.stateNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
@@ -914,18 +921,18 @@ machineDefn sModel mtype winX winY =
         NPDA ->
             group
                 [ machineHeader
-                , latex 500 18 "blank" "let\\ M = (Q,\\Sigma,\\Gamma,\\delta,s,\\bot,F)" AlignLeft
+                , latex 500 18 "blank" "\\textrm{let}\\ M = (Q,\\Sigma,\\Gamma,\\delta,s,\\bot,F)" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 25 )
-                , latex 500 14 "blank" "where" AlignLeft
+                , latex 500 14 "blank" "\\textrm{where}" AlignLeft
                     |> move ( -winX / 2 + 500, winY / 6 - 45 )
                 , latex 500 18 "blank" ("Q = \\{ " ++ String.join "," (Dict.values machine.stateNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
                 , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl (Set.union << .inputLabel) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 90 )
-                , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| List.foldl (\t s -> Set.insert t.stackTop (Set.insert t.stackPush s)) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
-                    |> move ( -winX / 2 + 510, winY / 6 - 90 )
-                , latex 500 18 "blank" "\\delta = (above)" AlignLeft
+                , latex 500 18 "blank" ("\\Gamma = \\{ " ++ String.join "," (Set.toList <| List.foldl (\t s -> Set.insert t.stackTop (Set.insert t.stackPush s)) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 115 )
+                , latex 500 18 "blank" "\\delta = (above)" AlignLeft
+                    |> move ( -winX / 2 + 510, winY / 6 - 135 )
                 , latex 500
                     14
                     "blank"
@@ -942,9 +949,11 @@ machineDefn sModel mtype winX winY =
                            )
                     )
                     AlignLeft
-                    |> move ( -winX / 2 + 510, winY / 6 - 140 )
-                , latex 500 18 "blank" ("F = \\{ " ++ String.join "," (List.map getStateName <| Set.toList <| machine.final) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 160 )
+                , latex 500 14 "blank" "\\bot = \\bot" AlignLeft
+                    |> move ( -winX / 2 + 510, winY / 6 - 180 )
+                , latex 500 18 "blank" ("F = \\{ " ++ String.join "," (List.map getStateName <| Set.toList <| machine.final) ++ " \\}") AlignLeft
+                    |> move ( -winX / 2 + 510, winY / 6 - 200 )
                 ]
 
 

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -2,7 +2,6 @@ module Simulating exposing (HoverError, InputTape, Model(..), Msg(..), Persisten
 
 import Array exposing (Array)
 import Browser.Events
-import Debug
 import Dict exposing (Dict)
 import Environment exposing (Environment)
 import Error exposing (..)
@@ -1182,7 +1181,17 @@ machineDefn sModel mtype winX winY =
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
                 , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl (Set.union << .inputLabel) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 90 )
-                , latex 500 18 "blank" ("\\Gamma = \\{ " ++ String.join "," (Set.toList <| Set.fromList <| List.concatMap (\lab -> lab.stackTop :: lab.stackPush) <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
+                , latex 500 18 "blank" ("\\Gamma = \\{ " 
+                        ++ String.join "," 
+                            (Dict.values machine.transitionNames
+                                |> List.concatMap (\lab -> lab.stackTop :: lab.stackPush) 
+                                |> Set.fromList 
+                                |> Set.remove "\\bot" 
+                                |> Set.remove "\\epsilon"
+                                |> Set.remove " "
+                                |> Set.toList)
+                             ++ " \\}")
+                        AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 115 )
                 , latex 500 18 "blank" "\\delta = (above)" AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 135 )

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -263,7 +263,7 @@ paginateConfigs paginateStart winX cfgWithLengths =
             [ group <|
                 List.map2 (\cfg moveAmt -> cfg |> move ( -initLeftPos + moveAmt, 0 ))
                     (Array.toList <| Array.slice paginateStart paginateEnd cfgArr)
-                    (Debug.log "shiftAmountByIdx" <| shiftAmountByIdx <| Array.toList <| Array.slice paginateStart paginateEnd lengthArr)
+                    (shiftAmountByIdx <| Array.toList <| Array.slice paginateStart paginateEnd lengthArr)
             , paginateButtons
             , paginateInfo
             ]
@@ -1505,7 +1505,7 @@ nextConfig tNames d tape acceptCond finals ({ stack, state, status, tapePos } as
                                                         Alive
 
                                                     FinalState ->
-                                                        if Set.member sId finals && newTapePos == Array.length tape then
+                                                        if Set.member sId finals && newTapePos == (Array.length tape - 1) then
                                                             Success
 
                                                         else

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -457,10 +457,12 @@ update env msg ( model, pModel, sModel ) =
                                 |> Maybe.withDefault Array.empty
 
                         newCfgs = nextConfigRel oldMachine.transitionNames oldMachine.delta tape pModel.npdaAcceptCond sModel.machine.final cfgs
+
+                        newStates = configToStates newCfgs
                     in
-                        ( ( RunningNPDA newCfgs tId, pModel, sModel), False, Cmd.none )
+                        ( ( RunningNPDA newCfgs tId, { pModel | currentStates = newStates }, sModel), False, Cmd.none )
                 _ ->
-                    ( ( model, pModel, sModel ), False, Cmd.none )
+                    ( ( model, pModel , sModel ), False, Cmd.none )
 
         RunTape tId ->
             case machineType of
@@ -1223,6 +1225,9 @@ deltaHat tNames d ch states =
 
 -- NPDA functions
             
+configToStates : List Configuration -> Set StateID
+configToStates = List.filter (\cfg -> cfg.status == Alive || cfg.status == Success) >> List.map .state >> Set.fromList 
+
 nextConfigRel : TransitionNames -> Delta -> InputTape -> AcceptCond -> Set StateID -> List Configuration -> List Configuration
 nextConfigRel tNames d tape acceptCond finals cfgs =
     List.concatMap (nextConfig tNames d tape acceptCond finals) cfgs

--- a/src/Simulating.elm
+++ b/src/Simulating.elm
@@ -129,7 +129,7 @@ checkTape sModel inp =
             sModel.machine.transitionNames
 
         allTransitionLabels =
-            List.foldr Set.union Set.empty <| Dict.values tNames
+            List.foldr (Set.union << .inputLabel) Set.empty <| Dict.values tNames
 
         arrFilter =
             Array.filter (\v -> not <| Set.member v allTransitionLabels) inp
@@ -507,7 +507,12 @@ update env msg ( model, pModel, sModel ) =
                                         -1
 
                             chars =
-                                Array.fromList <| Set.toList <| Set.remove "\\epsilon" <| List.foldr Set.union Set.empty <| Dict.values oldMachine.transitionNames
+                                Array.fromList <|
+                                    Set.toList <|
+                                        Set.remove "\\epsilon" <|
+                                            List.foldr Set.union Set.empty <|
+                                                List.map .inputLabel <|
+                                                    Dict.values oldMachine.transitionNames
 
                             newChar =
                                 Array.get charCode chars
@@ -672,7 +677,12 @@ view env ( model, pModel, sModel ) =
 
         chars =
             -- This is broken?
-            Set.toList <| Set.remove "\\epsilon" <| List.foldr Set.union Set.empty <| Dict.values oldMachine.transitionNames
+            -- 2021-07-31 TODO: Investigate why this is broken
+            Set.toList <|
+                Set.remove "\\epsilon" <|
+                    List.foldr Set.union Set.empty <|
+                        List.map .inputLabel <|
+                            Dict.values oldMachine.transitionNames
 
         menu =
             group <|
@@ -757,7 +767,7 @@ view env ( model, pModel, sModel ) =
                         |> move ( -10 * toFloat (Array.length tape), winY / 6 - 65 )
                     ]
                     |> move ( 0, -winY / 3 )
-        , (GraphicSVG.map MachineMsg <| Machine.view env Regular sModel.machine pModel.currentStates transMistakes) |> move ( 0, winY / 6 )
+        , (GraphicSVG.map MachineMsg <| Machine.view env Regular sModel.machineType sModel.machine pModel.currentStates transMistakes) |> move ( 0, winY / 6 )
         , machineModeButtons sModel.machineType winX winY ChangeMachine
         ]
 
@@ -793,7 +803,7 @@ machineDefn sModel mtype winX winY =
                     |> move ( -winX / 2 + 500, winY / 6 - 45 )
                 , latex 500 18 "blank" ("Q = \\{ " ++ String.join "," (Dict.values machine.stateNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
-                , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl Set.union Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
+                , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl (Set.union << .inputLabel) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 90 )
                 , latex 500 18 "blank" "\\Delta = (above)" AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 115 )
@@ -812,7 +822,7 @@ machineDefn sModel mtype winX winY =
                     |> move ( -winX / 2 + 500, winY / 6 - 45 )
                 , latex 500 18 "blank" ("Q = \\{ " ++ String.join "," (Dict.values machine.stateNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 65 )
-                , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl Set.union Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
+                , latex 500 18 "blank" ("\\Sigma = \\{ " ++ String.join "," (Set.toList <| Set.remove "\\epsilon" <| List.foldl (Set.union << .inputLabel) Set.empty <| Dict.values machine.transitionNames) ++ " \\}") AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 90 )
                 , latex 500 18 "blank" "\\delta = (above)" AlignLeft
                     |> move ( -winX / 2 + 510, winY / 6 - 115 )
@@ -848,7 +858,7 @@ epsTrans tNames d states =
         getName trans =
             case Dict.get trans tNames of
                 Just n ->
-                    renderSet2String n
+                    renderSet2String n.inputLabel
 
                 _ ->
                     ""
@@ -893,7 +903,7 @@ delta tNames d ch state =
         getName trans =
             case Dict.get trans tNames of
                 Just n ->
-                    n
+                    n.inputLabel
 
                 _ ->
                     Set.empty

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -76,6 +76,21 @@ textBox txt w h place msg =
                 []
 
 
+textBox3 : ( String, String, String ) -> Float -> Float -> ( String, String, String ) -> (String -> msg) -> Shape msg
+textBox3 ( t1, t2, t3 ) w h ( p1, p2, p3 ) msg =
+    let
+        box1 =
+            textBox t1 w h p1 msg |> move ( 0, h )
+
+        box2 =
+            textBox t2 w h p2 msg
+
+        box3 =
+            textBox t3 w h p3 msg |> move ( 0, -h )
+    in
+    group [ box1, box2, box3 ]
+
+
 newMsg : msg -> Cmd msg
 newMsg msg =
     Task.perform identity <| Task.succeed msg

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -76,17 +76,17 @@ textBox txt w h place msg =
                 []
 
 
-textBox3 : ( String, String, String ) -> Float -> Float -> ( String, String, String ) -> (String -> msg) -> Shape msg
-textBox3 ( t1, t2, t3 ) w h ( p1, p2, p3 ) msg =
+textBox3 : ( String, String, String ) -> Float -> Float -> ( String, String, String ) -> (String -> msg) -> (String -> msg) -> (String -> msg) -> Shape msg
+textBox3 ( t1, t2, t3 ) w h ( p1, p2, p3 ) msg1 msg2 msg3 =
     let
         box1 =
-            textBox t1 w h p1 msg |> move ( 0, h )
+            textBox t1 w h p1 msg1 |> move ( 0, h )
 
         box2 =
-            textBox t2 w h p2 msg
+            textBox t2 w h p2 msg2
 
         box3 =
-            textBox t3 w h p3 msg |> move ( 0, -h )
+            textBox t3 w h p3 msg3 |> move ( 0, -h )
     in
     group [ box1, box2, box3 ]
 

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -64,7 +64,7 @@ textBox txt w h place msg =
     move ( -w / 2, h / 2 ) <|
         html (w * 1.5) (h * 1.5) <|
             input
-                [ id "input"
+                [ id <| "input" ++ place
                 , placeholder place
                 , onInput msg
                 , value txt


### PR DESCRIPTION
This will allow users to build, simulate and export NPDA machines on finsm.

Features include:
- Build mode that allows users to specify their transitions as a triple consisting of the next tape input, the current stack state, and a characters to push onto the stack (must be space separated, and also allows LaTeX characters).
- New simulation mode for NPDAs that shows a list of active configurations (consisting of current state, current stack, current tape position and an indicator on if the configuration is stuck, active, or in an accepting state). The configuration list also automatically paginates if there are more than a certain amount of configurations active. **WARNING: Having too many active configurations WILL slow your browser down**.
- Export mode that will also render LaTeX in the transition label.

Design decisions:
- A separate simulation interface for NPDAs specifically, for viewing NPDA configurations. An open question is if we should standardize tape simulation to have a separate view for DFA/NFAs as well.
- The underlying machine type is an NPDA, but is used to represent DFAs and NFAs as well. Functions that need to differentiate on the type of machine it is operating on must have an additional parameter describing the type of the machine.

Next steps:
- Decide if we should standardize the tape simulation to behave the same for all machine types.
- Stress test to find out the tolerance on how many active configurations are allowed, and also to find if there are bugs in the implementation.
- Decide if we should have a separate Bootstrap card for instantiating an initial NPDA (and it would probably be the balanced parenthesis stock example).
- Move on to adding full-fledged Turing Machines? :)